### PR TITLE
ci: reverts ava to 3.x since 4.x breaks tests on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,19 @@
   "dependencies": {
     "@11ty/eleventy-img": "^2.0.0",
     "cheerio": "^1.0.0-rc.10",
-    "debug": "^4.3.3"
+    "debug": "^4.3.4"
   },
   "devDependencies": {
-    "ava": "^4.1.0",
+    "ava": "^3.15.0",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-xo-space": "^0.32.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "image-size": "^1.0.1",
-    "lint-staged": "^12.3.5",
+    "lint-staged": "^12.3.7",
     "nyc": "^15.1.0",
-    "prettier": "^2.5.1",
+    "prettier": "^2.6.0",
     "rimraf": "^3.0.2"
   },
   "lint-staged": {


### PR DESCRIPTION
- Updates other NPM packages
